### PR TITLE
add helm chart release pipeline

### DIFF
--- a/.github/chart-testing.yaml
+++ b/.github/chart-testing.yaml
@@ -1,0 +1,7 @@
+remote: origin
+target-branch: main
+debug: true
+check-version-increment: true
+upgrade: true
+validate-chart-schema: true
+validate-yaml: true

--- a/.github/lint.sh
+++ b/.github/lint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+CT_ARGS=""
+GIT_SAFE_DIR="false"
+
+if [ "$GIT_SAFE_DIR" != "true" ]; then
+    git config --global --add safe.directory /charts/chart
+fi
+
+CT_ARGS="--charts ${PWD}/charts"
+
+ct lint --config=./.github/chart-testing.yaml

--- a/.github/test.sh
+++ b/.github/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/helm unittest --color ./chart/benthos-captain;

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,0 +1,68 @@
+name: Release Chart
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name blobbot-helm
+          git config user.email blobbot-helm@github.com
+
+      - name: Get chart.yaml verison
+        id: chart_version
+        run: |
+          echo "CHART_VERSION=$(grep -o 'version: [0-9.]*' Chart.yaml | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: tag_exists
+        run: |
+          if ! git show-ref --verify --quiet "refs/tags/chart-${{ steps.chart_version.outputs.CHART_VERSION }}"; then
+              TAG_EXISTS=false
+          else
+              TAG_EXISTS=true
+          fi
+
+          echo "TAG_EXISTS=$TAG_EXISTS" >> $GITHUB_OUTPUT
+
+      - name: Tag release
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.chart_version.outputs.CHART_VERSION }}
+          tag_prefix: "chart-"
+        if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
+
+      - name: Create release
+        if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+
+      - name: Publish Helm chart
+        if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
+        uses: stefanprodan/helm-gh-pages@89c6698c192e70ed0e495bee7d3d1ca5b477fe82
+        with:
+          token: ${{ secrets.CHARTS_REPO_TOKEN }}
+          owner: benthosdev
+          repository: charts
+          branch: main
+          target_dir: benthos
+          index_dir: .
+          charts_dir: chart/
+          charts_url: https://benthosdev.github.io/charts
+          commit_username: blobbot-helm
+          commit_email: blobbot-helm@github.com

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -1,0 +1,26 @@
+name: Test chart
+
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Test
+        run: make chart-test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 
+chart-test: chart-lint
+	docker run ${DOCKER_ARGS} --entrypoint /bin/sh --rm -v $(CURDIR):/charts -w /charts helmunittest/helm-unittest:3.11.1-0.3.0 /charts/.github/test.sh
+
+chart-lint:
+	docker run ${DOCKER_ARGS} --env GIT_SAFE_DIR="true" --entrypoint /bin/sh --rm -v $(CURDIR):/charts -w /charts quay.io/helmpack/chart-testing:v3.10.1 /charts/.github/lint.sh
+
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.


### PR DESCRIPTION
This PR adds a pipeline to release the chart to the new central chart repo - https://github.com/benthosdev/charts