### PR TITLE
remove templating from CRD

### DIFF
--- a/chart/crds/pipeline.yaml
+++ b/chart/crds/pipeline.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: pipelines.captain.benthos.dev
   labels:
-  {{- include "benthos-captain.labels" . | nindent 4 }}
+    app: benthos-captain
 spec:
   group: captain.benthos.dev
   names:


### PR DESCRIPTION
Helm doesnt support templating in the `crds/` directory...

```
$ helm install benthos/benthos-captain --generate-name
Error: failed to install CRD crds/pipeline.yaml: error parsing : error converting YAML to JSON: yaml: line 7: could not find expected ':'\n",
```

Details:
```
$ helm version
version.BuildInfo{Version:"v3.15.2", GitCommit:"1a500d5625419a524fdae4b33de351cc4f58ec35", GitTreeState:"clean", GoVersion:"go1.22.4"}
```